### PR TITLE
Fix recipe identifier to improve installation for straight and elpaca

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ install straight.el, and then add the following snippet into your emacs
 configuration:
 ``` emacs-lisp
 (straight-use-package
-  '(nano-emacs :type git :host github :repo "rougier/nano-emacs"))
+  '(nano :type git :host github :repo "rougier/nano-emacs"))
 ```
 from here, you may either `(require 'nano)` to pull in the default nano
 configuration, or call for the different modules. The only mandatory module


### PR DESCRIPTION
Using `nano-emacs` as the recipe identifier for elpaca (and straight) breaks heuristics which find the main file.

The elpaca and straight.el author recommends changing the recipe to make this more explicit.

See the upstream elpaca bug with fix and recommendation:

https://github.com/progfolio/elpaca/issues/178#issuecomment-1700326423